### PR TITLE
Revert "added MSTest ProjectTypeGuids to Spec projects to make them execu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@
 _ReSharper*/
 *.vs10x
 Source/Gallio Reports
-Source/TestResults

--- a/Source/FluentMetadata.Core.Specs/FluentMetadata.Core.Specs.csproj
+++ b/Source/FluentMetadata.Core.Specs/FluentMetadata.Core.Specs.csproj
@@ -6,15 +6,15 @@
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{A699E2AB-B62B-4F0D-90C4-C39500430A70}</ProjectGuid>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>FluentMetadata.Specs</RootNamespace>
     <AssemblyName>FluentMetadata.Core.Specs</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <FileUpgradeFlags>0</FileUpgradeFlags>
-    <OldToolsVersion>4.0</OldToolsVersion>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation />
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>

--- a/Source/FluentMetadata.EntityFramework.Specs/FluentMetadata.EntityFramework.Specs.csproj
+++ b/Source/FluentMetadata.EntityFramework.Specs/FluentMetadata.EntityFramework.Specs.csproj
@@ -6,7 +6,6 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{5D1FB10C-0618-4FAE-A5E8-558D791E15AA}</ProjectGuid>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>FluentMetadata.EntityFramework.Specs</RootNamespace>

--- a/Source/FluentMetadata.MVC.Specs/FluentMetadata.MVC.Specs.csproj
+++ b/Source/FluentMetadata.MVC.Specs/FluentMetadata.MVC.Specs.csproj
@@ -6,12 +6,11 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{EB81FC78-9EAC-4664-989C-83A81F8D9D3D}</ProjectGuid>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>FluentMetadata.MVC.Specs</RootNamespace>
     <AssemblyName>FluentMetadata.MVC.Specs</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>


### PR DESCRIPTION
Hey Albert,

Sorry, aber der letzte Commit auf dem toolsSupport branch crashed den TestRunner. Weiß auch nicht, wie mir das entgangen ist. Wie mein Test ergab, liegt es an der Umstellung auf .Net4. Ich habe auch versucht, die Tests auf den neuesten Versionen von XUnit & BDDExtensions laufen zu lassen, bringt aber auch nichts. Kannst dir ja mal den Branch xUnitUpdate ziehen und es dir anschauen. Du kennst dich mit XUnit ja besser aus.

Obwohl das Problem gelöst werden muss, wenn ich die Tests gegen MVC3 (nur .Net4) laufen lassen will, habe ich als schnellen Fix auf toolsSupport einen Revert committed.

Gruß, Holger
###### 

Revert "added MSTest ProjectTypeGuids to Spec projects to make them executable using the Visual Studio Test Runner and the Gallio VS addin (had to upgrade .n3.5 projects to 4.0 for that)"

This reverts commit 9864c699bb40067b9a50030306726496a4594272.

For some reason the test runner crashed after this commit. I suspect the upgrade to .Net 4.
